### PR TITLE
Fix assets:precompile early return for Webpacker-only scenario:

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -61,7 +61,7 @@ WARNING
 
   def run_assets_precompile_rake_task
     log("assets_precompile") do
-      if Dir.glob("public/assets/{.sprockets-manifest-*.json,manifest-*.json}", File::FNM_DOTMATCH).any?
+      if Dir.glob("public/(assets|packs)/{.sprockets-manifest-*.json,manifest-*.json}", File::FNM_DOTMATCH).any?
         puts "Detected manifest file, assuming assets were compiled locally"
         return true
       end


### PR DESCRIPTION
Update: this is wrong. Reverted in #2 

---

Webpacker emits public/packs/manifest.json instead of public/assets/manifest.
The current behavior of "Detected manifest file, assuming assets were compiled locally" doesn't work for those who only use Webpakcer but not Sprocket.

TODO: Since Webpacker is introduced in Rails 5.1, perhaps I should
refactor and move this Regex to rails5.rb