### PR TITLE
Revert "Fix assets:precompile early return for Webpacker-only scenario:"

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -61,7 +61,7 @@ WARNING
 
   def run_assets_precompile_rake_task
     log("assets_precompile") do
-      if Dir.glob("public/(assets|packs)/{.sprockets-manifest-*.json,manifest-*.json}", File::FNM_DOTMATCH).any?
+      if Dir.glob("public/assets/{.sprockets-manifest-*.json,manifest-*.json}", File::FNM_DOTMATCH).any?
         puts "Detected manifest file, assuming assets were compiled locally"
         return true
       end


### PR DESCRIPTION
Actually, we do also have `public/assets/.sprockets-manifest-3ac0576d16d30247c050233bd86fc4d9.json` so #1 doesn't make sense.

![image](https://user-images.githubusercontent.com/12410942/159834244-85c40ef2-a7ae-4a07-abf8-264c888b066c.png)
